### PR TITLE
added contributors to OSM attribution

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -723,7 +723,7 @@ function setBasemap(basemap){
     bootleaf.basemapLayer = L.esri.basemapLayer(esriTheme, options);
   } else if (basemap.type === 'tiled'){
     if (basemap.id === 'OpenStreetMap') {
-      options.attribution = "<a href='http://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap</a>";
+      options.attribution = "<a href='http://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap contributors</a>";
     }
     bootleaf.basemapLayer = L.tileLayer(basemap.url, options);
   } else if (basemap.type === 'mapbox'){


### PR DESCRIPTION
From the [OSM copyright website](https://www.openstreetmap.org/copyright/) I gathered the requested attribution is `© OpenStreetMap contributors`. So we should add the contributors.